### PR TITLE
feat: experimental build flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,8 @@ ENV SERVER_DIR="/vein-server/server" \
     RESTART_CRON="0 4 * * *" \
     SCHEDULED_UPDATE="False" \
     UPDATE_CRON="0 3 * * *" \
-    MANUAL_CONFIG="False"
+    MANUAL_CONFIG="False" \
+    EXPERIMENTAL_BUILD="False"
 
 EXPOSE 7777/udp 27015/udp 8080/tcp
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The table below shows all the available environment variables and their default 
 | `UPDATE_CRON` | Cron expression for scheduled updates. Default is every Sunday at 5am. | `0 5 * * 0` |
 | `BACKUP_BEFORE_UPDATE` | Determines if the server should backup itself before updating. | `True` |
 | `UPDATE_ON_BOOT` | Determines if the server should update itself when it starts. If this is set to `False` then the server will only update if `SCHEDULED_UPDATE=True`, then it will update on the schedule specified by `UPDATE_CRON`. | `True` |
+| `EXPERIMENTAL_BUILD` | If set to `True`, downloads the experimental beta build instead of the stable release. Uses a different Steam App ID and beta branch. | `False` |
 | `SCHEDULED_BACKUP` | Enable scheduled backups of the server. | `False` |
 | `BACKUP_CRON` | Cron expression for scheduled backups. Default is every day at 6am. | `0 6 * * *` |
 | `BACKUP_ON_STOP` | Determines if the server should backup itself when the container stops. | `True` |

--- a/bin/vein-updater.sh
+++ b/bin/vein-updater.sh
@@ -21,12 +21,22 @@ launch_vein_server() {
 }
 
 download_and_update_vein_server() {
+    local app_id="2131400"
+    local beta_flag=""
+    local validate_flag="validate"
+
+    if [ "$EXPERIMENTAL_BUILD" = "True" ]; then
+        echo "Updater - Using Experimental Build"
+        app_id="2600250"
+        beta_flag="-beta experimental"
+    fi
+
     if [ "$SKIP_FILE_VALIDATION" = "True" ]; then
         echo "Updater - Skipping SteamCMD Validation of Server Files"
-        local app_update="+app_update 2131400"
-    else
-        local app_update="+app_update 2131400 validate"
+        validate_flag=""
     fi
+
+    local app_update="+app_update $app_id $beta_flag $validate_flag"
 
     local install_dir="+force_install_dir $SERVER_DIR"
 


### PR DESCRIPTION
Added an experimental build flag env var that will launch the game using an experimental build of the game. I have not validated if it is possible to bounce back and forth between experimental builds and non experimental builds.