### PR TITLE
fix: add delay before server restart to prevent SteamAPI init failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,7 @@ vein-server/
 |----------|---------|-------------|
 | `SCHEDULED_RESTART` | False | Enable restarts |
 | `RESTART_CRON` | "0 4 * * *" | Restart schedule |
+| `SERVER_RESTART_DELAY` | 20 | Seconds to wait after stop before starting server (prevents SteamAPI init failures). Set to 0 or lower to disable. |
 | `SCHEDULED_UPDATE` | False | Enable updates |
 | `UPDATE_CRON` | "0 3 * * *" | Update schedule |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ ENV SERVER_DIR="/vein-server/server" \
     BACKUP_CRON="0 6 * * *" \
     SCHEDULED_RESTART="False" \
     RESTART_CRON="0 4 * * *" \
+    SERVER_RESTART_DELAY="20" \
     SCHEDULED_UPDATE="False" \
     UPDATE_CRON="0 3 * * *" \
     MANUAL_CONFIG="False" \

--- a/bin/system-bootstrap.sh
+++ b/bin/system-bootstrap.sh
@@ -63,8 +63,9 @@ setup_cron_jobs() {
 }
 
 setup_cron_scheduled_restart() {
+  local delay="${SERVER_RESTART_DELAY:-20}"
   echo "$(date) - Server Restart CRON Scheduled For: $RESTART_CRON" >> /vein-server/logs/cron.log
-  echo "$RESTART_CRON supervisorctl restart vein-server && \
+  echo "$RESTART_CRON supervisorctl stop vein-server && sleep $delay && supervisorctl start vein-server && \
     echo \"\$(date) - CRON Restart - vein-server\" >> /vein-server/logs/cron.log"
 }
 

--- a/bin/vein-backup.sh
+++ b/bin/vein-backup.sh
@@ -18,7 +18,16 @@ main() {
 start_vein_server() {
   if [[ "$SCRIPT_PARAM" = "restart" ]]; then
     echo "Backup Process - Starting Vein Server After Backup"
+    wait_before_server_start
     supervisorctl start vein-server
+  fi
+}
+
+wait_before_server_start() {
+  local delay="${SERVER_RESTART_DELAY:-20}"
+  if [[ "$delay" -gt 0 ]]; then
+    echo "Backup Process - Waiting ${delay}s Before Starting Server (SERVER_RESTART_DELAY)"
+    sleep "$delay"
   fi
 }
 


### PR DESCRIPTION
# Summary
* Add SERVER_RESTART_DELAY environment variable (default: 20 seconds) to introduce a delay between stopping and starting the server during restarts
* Apply delay to both scheduled restarts (via cron) and backup-and-restart operations
* Setting the delay to 0 or lower disables the wait

# Problem
After scheduled restarts, the SteamAPI occasionally fails to initialize with:

`Error: RamjetSteamSockets: Could not initialize SteamSockets, got error:  RamjetSteamSockets: Could not initialize the game server SteamAPI!`

This causes continuous heartbeat failures (Failed to heartbeat (no connection string)) and removes the server from the Steam server browser.

# Speculated Root Cause
When the server restarts, the new instance attempts to initialize SteamAPI before the previous instance has fully released its network sockets and resources.