### PR TITLE
fix: made vein server launch use child process

### DIFF
--- a/bin/vein-server.sh
+++ b/bin/vein-server.sh
@@ -10,7 +10,11 @@ trap cleanup SIGTERM SIGINT
 
 cleanup() {
     echo "Vein Server - Shutdown signal received, stopping server"
-    pkill -TERM VeinServer || true
+    # Kill the actual VeinServer binary (child of VeinServer.sh)
+    pkill -TERM -f "VeinServer-Linux-Test" 2>/dev/null || true
+    if [ -n "$SERVER_PID" ]; then
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
     exit 0
 }
 
@@ -27,8 +31,14 @@ start_server() {
 
     echo "Vein Server - Launching server process"
 
-    # Run server in foreground - output goes directly to stdout/stderr
-    exec ./VeinServer.sh -log
+    # Run server as child process so we can catch signals and forward them
+    ./VeinServer.sh -log &
+    SERVER_PID=$!
+
+    echo "Vein Server - Server started with PID $SERVER_PID"
+
+    # Wait for server to exit
+    wait "$SERVER_PID"
 }
 
 start_server


### PR DESCRIPTION
# Summary
* Fix server restart failures caused by the game server process not being properly terminated when supervisord stops the vein-server service
* The VeinServer.sh wrapper script spawns VeinServer-Linux-Test as a child process, but using exec replaced our shell, preventing signal handling from working correctly

# Problem
1. When supervisord sent SIGTERM to stop vein-server during scheduled restarts:
2. The exec ./VeinServer.sh replaced our script's process
3. VeinServer.sh spawned VeinServer-Linux-Test as a child
4. SIGTERM killed VeinServer.sh but left the actual game binary running

On restart, Steam API initialization failed because port 27015 was still bound by the orphaned process

```bash
CreateBoundSocket: ::bind couldn't find an open port between 27015 and 27015
LogSteamShared: Warning: Steam Dedicated Server API failed to initialize.
LogRamjetNetworking: Error: RamjetSteamSockets: Could not initialize SteamSockets
```

# Solution
* Run VeinServer.sh as a background child process instead of using exec
* Keep our script alive to catch SIGTERM via trap
* Kill the actual VeinServer-Linux-Test binary by name in the cleanup handler
* Wait for the child process to exit cleanly