### PR TITLE
fix: pass port arguments to VeinServer.sh for configurable ports

### DIFF
--- a/bin/vein-server.sh
+++ b/bin/vein-server.sh
@@ -31,8 +31,15 @@ start_server() {
 
     echo "Vein Server - Launching server process"
 
+    # Build server arguments
+    SERVER_ARGS="-log"
+    SERVER_ARGS="${SERVER_ARGS} -Port=${VEIN_SERVER_PORT:-7777}"
+    SERVER_ARGS="${SERVER_ARGS} -QueryPort=${VEIN_SERVER_QUERY_PORT:-27015}"
+
+    echo "Vein Server - Args: ${SERVER_ARGS}"
+
     # Run server as child process so we can catch signals and forward them
-    ./VeinServer.sh -log &
+    ./VeinServer.sh ${SERVER_ARGS} &
     SERVER_PID=$!
 
     echo "Vein Server - Server started with PID $SERVER_PID"


### PR DESCRIPTION
## Summary
- Pass `-Port` and `-QueryPort` arguments to `VeinServer.sh` using environment variables
- Fixes port configuration not being applied when using `VEIN_SERVER_PORT` and `VEIN_SERVER_QUERY_PORT`
- Defaults to 7777 (game port) and 27015 (query port) if not specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)