### PR TITLE
fix: replace PR creation with direct merge in sync-main-to-next workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -111,12 +110,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN_SEMANTIC_RELEASE }}
 
-      - name: Create sync PR
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.GH_TOKEN_SEMANTIC_RELEASE }}
-          branch: chore/sync-main-to-next
-          base: next
-          title: "chore: sync main to next"
-          body: "Automated PR to sync changes from main back to next."
-          delete-branch: true
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into next
+        run: |
+          git fetch origin next
+          git checkout next
+          git merge origin/main -m "chore: sync main back to next [skip ci]"
+          git push origin next


### PR DESCRIPTION
## Summary
- Fixed the `sync-main-to-next` workflow job that was not working correctly
- Replaced `peter-evans/create-pull-request` action with direct git merge commands
- This fixes semantic-release versioning issues after production releases

## Problem
After merging a release PR from `next` to `main` (with merge commit), the `next` branch was missing the merge commit. This caused semantic-release to create incorrect pre-release versions (e.g., 1.2.2-next.5 instead of 1.3.0-next.1).

The previous attempt to fix this used `peter-evans/create-pull-request`, but that action requires file changes to commit - it doesn't merge git history.

## Solution
The workflow now:
1. Configures git with github-actions bot credentials
2. Fetches and checks out the `next` branch
3. Merges `main` into `next` with a proper merge commit
4. Pushes the merge commit back to `next`

The merge commit message includes `[skip ci]` to prevent triggering another release workflow.

## Test plan
- Merge this PR to `next`
- Wait for the next production release to `main`
- Verify the `sync-main-to-next` job runs successfully
- Verify the next feature merged to `next` gets correct version (e.g., 1.3.0-next.1 instead of 1.2.2-next.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)