### PR TITLE
docs: fix inaccuracies in documentation and deployment examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ vein-server/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `UPDATE_ON_BOOT` | True | Update on container start |
-| `SKIP_FILE_VALIDATION` | False | Skip SteamCMD file validation (faster updates) |
+| `VALIDATE_SERVER_FILES` | True | Validate server files with SteamCMD during updates (set to False to skip validation for faster updates) |
 | `EXPERIMENTAL_BUILD` | False | Use experimental build (App ID: 2600250) |
 | `MANUAL_CONFIG` | False | Skip config generation |
 
@@ -317,6 +317,7 @@ environment:
 |------|----------|-------------|
 | 7777 | UDP | Game server port (configurable via `VEIN_SERVER_PORT`) |
 | 27015 | UDP | Query port (configurable via `VEIN_SERVER_QUERY_PORT`) |
+| 8080 | TCP | HTTP query server (optional, for querying game data from running instance) |
 
 ### Health Check
 
@@ -433,7 +434,7 @@ docker exec vein-server supervisorctl tail -f vein-updater
 **Skip file validation for faster updates:**
 ```yaml
 environment:
-  SKIP_FILE_VALIDATION: "True"
+  VALIDATE_SERVER_FILES: "False"
 ```
 
 ### Scheduled Tasks Not Running

--- a/README.md
+++ b/README.md
@@ -92,15 +92,16 @@ The table below shows all the available environment variables and their default 
 
 | Variable | Description | Default |
 | --- | --- | :---: |
-| `TZ` | Sets the timezone of the container. See the table [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) and look in the TZ identifier column. Highly recommend to set this if you will be using any of the CRON variables. | `America/New_York` |
+| `TZ` | Sets the timezone of the container. See the table [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) and look in the TZ identifier column. Highly recommend to set this if you will be using any of the CRON variables. | (system default) |
 | `MANUAL_CONFIG` | If set to `True` then the container will not generate any config files. This is useful if you want to manage the config files yourself. | `False` |
 | `SCHEDULED_RESTART` | Enable scheduled restarts of the server. | `False` |
 | `BACKUP_ON_SCHEDULED_RESTART` | Determines if the server should backup itself before restarting. | `False` |
 | `RESTART_CRON` | Cron expression for scheduled restarts. Default is everyday at 4am. | `0 4 * * *` |
 | `SCHEDULED_UPDATE` | Enable scheduled updates of the server. | `False` |
-| `UPDATE_CRON` | Cron expression for scheduled updates. Default is every Sunday at 5am. | `0 5 * * 0` |
+| `UPDATE_CRON` | Cron expression for scheduled updates. Default is daily at 3am. | `0 3 * * *` |
 | `BACKUP_BEFORE_UPDATE` | Determines if the server should backup itself before updating. | `True` |
 | `UPDATE_ON_BOOT` | Determines if the server should update itself when it starts. If this is set to `False` then the server will only update if `SCHEDULED_UPDATE=True`, then it will update on the schedule specified by `UPDATE_CRON`. | `True` |
+| `VALIDATE_SERVER_FILES` | Validate server files with SteamCMD during updates. Set to `False` to skip validation for faster updates. | `True` |
 | `EXPERIMENTAL_BUILD` | If set to `True`, downloads the experimental beta build instead of the stable release. Uses a different Steam App ID and beta branch. | `False` |
 | `SCHEDULED_BACKUP` | Enable scheduled backups of the server. | `False` |
 | `BACKUP_CRON` | Cron expression for scheduled backups. Default is every day at 6am. | `0 6 * * *` |
@@ -126,6 +127,7 @@ The table below shows the default ports that are exposed by the container.
 | :---: | :---: | --- |
 | 7777 | UDP | Main game port |
 | 27015 | UDP | Steam query port |
+| 8080 | TCP | HTTP query server (optional, for querying game data) |
 
 Make sure you have Port Forwarding configured otherwise the server will not be accessible from the internet.
 

--- a/deployment-examples/docker-compose/advanced-docker-compose.yml
+++ b/deployment-examples/docker-compose/advanced-docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3'
 services:
   vein:
     container_name: vein
-    image: vein-server:latest
+    image: johnnyknighten/vein-server:latest
     restart: unless-stopped
     environment:
       # Server identity

--- a/deployment-examples/docker-compose/basic-docker-compose.yml
+++ b/deployment-examples/docker-compose/basic-docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3'
 services:
   vein:
     container_name: vein
-    image: vein-server:latest
+    image: johnnyknighten/vein-server:latest
     restart: unless-stopped
     environment:
       - VEIN_SERVER_NAME="Simple Vein Server"


### PR DESCRIPTION
## Summary

Comprehensive review and correction of all project documentation to ensure accuracy and consistency with the actual implementation.

## Changes

### Documentation Fixes
- Fixed docker-compose image references from `vein-server:latest` to `johnnyknighten/vein-server:latest`
- Corrected `UPDATE_CRON` description from "every Sunday at 5am" to "daily at 3am" (matching Dockerfile default)
- Fixed `TZ` default value from `America/New_York` to `(system default)` to accurately reflect behavior
- Added missing `VALIDATE_SERVER_FILES` environment variable documentation with correct variable name and default value
- Documented port 8080 as "HTTP query server (optional, for querying game data)"

### Docker Compose Improvements
- Removed deprecated `version: '3'` key from both compose files (obsolete in Docker Compose V2)

## Files Modified
- `README.md` - Environment variables and ports documentation
- `CLAUDE.md` - Environment variables, ports, and troubleshooting documentation
- `deployment-examples/docker-compose/basic-docker-compose.yml` - Image reference and version key
- `deployment-examples/docker-compose/advanced-docker-compose.yml` - Image reference and version key

## Testing
- [x] Reviewed all documentation files
- [x] Cross-referenced with actual implementation (Dockerfile, shell scripts)
- [x] Verified environment variable defaults match Dockerfile
- [x] Confirmed docker-compose examples use correct image reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)