### PR TITLE
fix: correct VALIDATE_SERVER_FILES variable name in updater script

### DIFF
--- a/bin/vein-updater.sh
+++ b/bin/vein-updater.sh
@@ -18,25 +18,25 @@ launch_vein_server() {
 
 download_and_update_vein_server() {
     local app_id="2131400"
-    local beta_flag=""
-    local validate_flag="validate"
+    local steamcmd_args=("+force_install_dir" "$SERVER_DIR" "+login" "anonymous")
 
-    if [ "$EXPERIMENTAL_BUILD" = "True" ]; then
+    if [[ "$EXPERIMENTAL_BUILD" = "True" ]]; then
         echo "Updater - Using Experimental Build"
         app_id="2600250"
-        beta_flag="-beta experimental"
+        steamcmd_args+=("+app_update" "$app_id" "-beta" "experimental")
+    else
+        steamcmd_args+=("+app_update" "$app_id")
     fi
 
-    if [ "$SKIP_FILE_VALIDATION" = "True" ]; then
+    if [[ "$VALIDATE_SERVER_FILES" != "False" ]]; then
+        steamcmd_args+=("validate")
+    else
         echo "Updater - Skipping SteamCMD Validation of Server Files"
-        validate_flag=""
     fi
 
-    local app_update="+app_update $app_id $beta_flag $validate_flag"
+    steamcmd_args+=("+quit")
 
-    local install_dir="+force_install_dir $SERVER_DIR"
-
-    steamcmd "$install_dir" +login anonymous "$app_update" +quit
+    steamcmd "${steamcmd_args[@]}"
 }
 
 main


### PR DESCRIPTION
## Summary

Fixes broken `VALIDATE_SERVER_FILES` environment variable in the updater script.

**Problem**: The script was checking for `SKIP_FILE_VALIDATION` (non-existent) instead of the documented `VALIDATE_SERVER_FILES` variable, making the validation toggle feature completely non-functional.

**Changes**:
- ✅ Fixed variable name: `SKIP_FILE_VALIDATION` → `VALIDATE_SERVER_FILES`
- ✅ Inverted logic to check `!= "False"` for clearer default case (validation enabled by default)
- ✅ Updated bracket syntax from `[ ]` to `[[ ]]` for consistency with codebase
- ✅ Refactored to use array-based argument construction for more robust SteamCMD command building
- ✅ Added else branch to experimental build logic for better code clarity

**Impact**: Users can now properly control SteamCMD file validation by setting `VALIDATE_SERVER_FILES=False` for faster updates.

## Test plan

- [x] Build container with fix
- [x] Test with `VALIDATE_SERVER_FILES=True` (default) - should validate files
- [x] Test with `VALIDATE_SERVER_FILES=False` - should skip validation (faster)
- [x] Verify SteamCMD output shows/hides validation messages correctly
- [x] Test both UPDATE_ON_BOOT and SCHEDULED_UPDATE scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)