### PR TITLE
fix: create .steam directory for steam user to fix SteamCMD initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN if ! id -u steam > /dev/null 2>&1; then \
         groupadd -g 1000 steam && \
         useradd -u 1000 -g 1000 -m -s /bin/bash steam; \
     fi && \
-    usermod -a -G crontab steam
+    usermod -a -G crontab steam && \
+    mkdir -p /home/steam/.steam && \
+    chown steam:steam /home/steam/.steam
 
 RUN mkdir -p \
     /vein-server/server \


### PR DESCRIPTION
## Summary
- Creates `/home/steam/.steam` directory during Docker image build to fix SteamCMD failing on first startup

## Problem
The base image `steamcmd/steamcmd:ubuntu-22` runs as root and creates `~/.steam` at `/root/.steam`. When the vein-server container runs SteamCMD as the `steam` user, it fails because `/home/steam/.steam` doesn't exist, resulting in:
```
ln: failed to create symbolic link '/home/steam/.steam/root': No such file or directory
ln: failed to create symbolic link '/home/steam/.steam/steam': No such file or directory
ERROR! Failed to install app '2131400' (Missing configuration)
```

## Solution
Added `mkdir -p /home/steam/.steam` and `chown steam:steam /home/steam/.steam` to the Dockerfile during user setup.

## Test plan
- [x] Built image successfully
- [x] Verified `/home/steam/.steam` directory exists with correct ownership
- [x] Ran SteamCMD as steam user - no symlink errors

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)